### PR TITLE
fix(ci): pin workflow actions to commit SHAs and bump to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
+# All `uses:` below are pinned to commit SHAs to eliminate supply-chain
+# risk from action-release spoofing. Bump via Dependabot (see
+# .github/dependabot.yml), which rewrites the SHA + version comment.
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -29,9 +32,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable tip
         with:
+          toolchain: stable
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -39,20 +43,23 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable tip
         with:
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
   docs:
     name: rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable tip
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo doc --no-deps --all-features --workspace
 
   test:
@@ -63,18 +70,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable tip
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --all-features --workspace --locked
 
   msrv:
     name: msrv (1.85)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # 1.85
+        with:
+          toolchain: "1.85"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # Build only — MSRV is a compile-time promise; dev-deps may
       # require a newer toolchain.
       - run: cargo build --all-features --workspace --locked
@@ -95,18 +106,22 @@ jobs:
           - name: all cloud features
             flags: --no-default-features --features aws,gcp,azure,digitalocean,hetzner,oci,k8s -p host-identity
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable tip
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build ${{ matrix.flags }} --locked
 
   manpage:
     name: man pages up to date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable tip
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Regenerate man pages
         run: cargo xtask
       - name: Verify no drift
@@ -120,8 +135,8 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
           command: check advisories bans licenses sources
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,9 @@ concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# All `uses:` below are pinned to commit SHAs to eliminate supply-chain
+# risk from action-release spoofing. Bump via Dependabot (see
+# .github/dependabot.yml), which rewrites the SHA + version comment.
 jobs:
   analyze:
     name: analyze (${{ matrix.language }})
@@ -32,15 +35,15 @@ jobs:
           - { language: python,  build-mode: none }
           - { language: rust,    build-mode: none }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Always check out the tag ref, not the event SHA. Critical for
       # workflow_dispatch where github.sha points at the branch HEAD.
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ steps.tag.outputs.tag }}
@@ -157,7 +157,7 @@ jobs:
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "ref=$TAG" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-notes
           path: release-notes.md
@@ -182,7 +182,7 @@ jobs:
           - { target: x86_64-pc-windows-msvc,     runner: windows-latest, cross: false }
           - { target: aarch64-pc-windows-msvc,    runner: windows-latest, cross: false }
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
@@ -306,7 +306,7 @@ jobs:
       # Archive (primary artefact). Uploading from a single flat dir
       # ensures the downloaded layout at Stage 4 is predictable:
       # merge-multiple leaves every file at the top of `release/`.
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: archive-${{ matrix.target }}
           path: |
@@ -314,7 +314,7 @@ jobs:
             dist/*.zip
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: debug-${{ matrix.target }}
           path: dist/debug/
@@ -332,7 +332,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu,  deb_arch: amd64 }
           - { target: aarch64-unknown-linux-gnu, deb_arch: arm64 }
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
@@ -346,7 +346,7 @@ jobs:
         with:
           tool: cargo-deb@${{ env.CARGO_DEB_VERSION }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-${{ matrix.target }}
           path: dist
@@ -380,7 +380,7 @@ jobs:
             --target "$TARGET" \
             --output "out/"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deb-${{ matrix.deb_arch }}
           path: out/*.deb
@@ -397,7 +397,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu,  rpm_arch: x86_64 }
           - { target: aarch64-unknown-linux-gnu, rpm_arch: aarch64 }
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
@@ -411,7 +411,7 @@ jobs:
         with:
           tool: cargo-generate-rpm@${{ env.CARGO_GENERATE_RPM_VERSION }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-${{ matrix.target }}
           path: dist
@@ -449,7 +449,7 @@ jobs:
             --payload-compress zstd \
             --output "out/"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rpm-${{ matrix.rpm_arch }}
           path: out/*.rpm
@@ -469,12 +469,12 @@ jobs:
           - { target: x86_64-unknown-linux-musl,  apk_arch: x86_64 }
           - { target: aarch64-unknown-linux-musl, apk_arch: aarch64 }
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-${{ matrix.target }}
           path: dist
@@ -543,7 +543,7 @@ jobs:
               cp /home/builder/hostid/APKBUILD /out/APKBUILD.${APK_ARCH}
             '
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: apk-${{ matrix.apk_arch }}
           path: out/apk/**
@@ -554,12 +554,12 @@ jobs:
     needs: [preflight, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-x86_64-unknown-freebsd
           path: dist
@@ -602,7 +602,7 @@ jobs:
               stage/usr/local/share/licenses/hostid/LICENSE-MIT
             pkg create -M +MANIFEST -r stage -o out
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: freebsd-pkg
           path: out/**
@@ -623,7 +623,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: matrix.arch == 'arm64'
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: deb-${{ matrix.arch }}
           path: dist
@@ -655,7 +655,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: matrix.arch == 'aarch64'
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rpm-${{ matrix.arch }}
           path: dist
@@ -690,7 +690,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: matrix.arch == 'aarch64'
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: apk-${{ matrix.arch }}
           path: dist
@@ -714,7 +714,7 @@ jobs:
     needs: [preflight, package-freebsd]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: freebsd-pkg
           path: dist
@@ -741,7 +741,7 @@ jobs:
           - { runner: macos-13,     target: x86_64-apple-darwin }
           - { runner: macos-latest, target: aarch64-apple-darwin }
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-${{ matrix.target }}
           path: dist
@@ -761,7 +761,7 @@ jobs:
     needs: [preflight, build]
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-x86_64-pc-windows-msvc
           path: dist
@@ -805,13 +805,13 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Gather all artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "*"
           path: incoming
@@ -875,7 +875,7 @@ jobs:
             -m release/SHA256SUMS -x release/SHA256SUMS.minisig
 
       - name: SLSA build provenance
-        uses: actions/attest-build-provenance@c4fbc648846ca6f503a13a2281a5e7b98aa57202 # v2.2.3
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             release/*.tar.gz
@@ -885,7 +885,7 @@ jobs:
             release/*.apk
             release/*.pkg
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-bundle
           path: release/
@@ -899,15 +899,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-bundle
           path: release
-      - uses: actions/download-artifact@d3f86a106a0bac45b6d6c40808f1e6cfcc3e3e65 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-notes
           path: .
@@ -1061,7 +1061,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}
@@ -1103,7 +1103,7 @@ jobs:
       contents: read
       attestations: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.ref }}


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout`, `actions/upload-artifact`,
  `actions/download-artifact`, and `actions/attest-build-provenance`
  to Node-24 majors ahead of the [2026-06-02 / 2026-09-16 Node 20
  deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
- Pins every `uses:` in `ci.yml` and `codeql.yml` to a full commit SHA
  with a trailing `# vX.Y.Z` comment, matching the supply-chain
  hardening already in place for `release.yml`.
- Adds the same `# All uses: below are pinned …` header to `ci.yml`
  and `codeql.yml`.

### Versions pinned

| Action | New major |
| --- | --- |
| `actions/checkout` | v6.0.2 |
| `actions/upload-artifact` | v7.0.1 |
| `actions/download-artifact` | v8.0.1 |
| `actions/attest-build-provenance` | v4.1.0 (prior v2.2.3 transitively loaded `actions/attest@v2.0.1` on Node 20) |
| `github/codeql-action/{init,analyze}` | v4.35.2 |
| `Swatinem/rust-cache` | v2.9.1 |
| `EmbarkStudios/cargo-deny-action` | v2.0.17 |
| `dtolnay/rust-toolchain` | current `master` SHA (`# stable tip` / `# 1.85`) |

Every `dtolnay/rust-toolchain` reference now passes an explicit
`with: toolchain:` input — required once the action is pinned to a
SHA rather than a tag like `@stable` / `@1.85`.

### Dependabot

`.github/dependabot.yml` already runs `github-actions` weekly with a
grouped `"*"` pattern — it rewrites both the SHA and the trailing
`# vX.Y.Z` comment automatically on future bumps, so no edit is
needed there.

Fixes #4

## Test plan

- [ ] CI matrix passes on this PR with no "Node.js 20 actions are
      deprecated" warning on any job summary
- [ ] CodeQL job succeeds
- [ ] Release workflow rehearsal via `workflow_dispatch` against
      `v1.0.0-rc1` — checkout, upload-artifact, download-artifact,
      and attest-build-provenance all succeed across the Linux /
      macOS / Windows / FreeBSD matrix