### PR TITLE
fix: ignore unset illumos hostid sentinel

### DIFF
--- a/crates/host-identity/CHANGELOG.md
+++ b/crates/host-identity/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `IllumosHostId` now rejects the `00000000` unset sentinel by returning
+  `Ok(None)` so the resolver falls through, matching
+  `SysctlKernHostId`. See [#9](https://github.com/dekobon/host-identity/issues/9).
+
 ## [1.0.0-rc1] - 2026-04-19
 
 Rehearsal pre-release of 1.0.0. Exercises the full release pipeline

--- a/crates/host-identity/src/sources/illumos.rs
+++ b/crates/host-identity/src/sources/illumos.rs
@@ -7,6 +7,9 @@
 //! [`sysinfo(2)`](https://illumos.org/man/2/sysinfo)
 //! (`SI_HW_SERIAL` / `SI_HW_PROVIDER`).
 //!
+//! This source rejects `0` (including zero-padded and `0x`-prefixed forms)
+//! because illumos documents `SI_HW_SERIAL` as returning `"0"` when unset.
+//!
 //! # Identity scope
 //!
 //! `IllumosHostId` is **per-host-OS**: `hostid(1)` reads a kernel
@@ -68,6 +71,51 @@ impl Source for IllumosHostId {
         let Ok(value) = std::str::from_utf8(&output.stdout) else {
             return Ok(None);
         };
-        Ok(normalize(value).map(|v| Probe::new(SourceKind::IllumosHostId, v)))
+        Ok(normalize(value)
+            .filter(|v| !is_zero_hostid(v))
+            .map(|v| Probe::new(SourceKind::IllumosHostId, v)))
+    }
+}
+
+fn is_zero_hostid(v: &str) -> bool {
+    let (digits, radix) = v
+        .strip_prefix("0x")
+        .or_else(|| v.strip_prefix("0X"))
+        .map_or((v, 10), |d| (d, 16));
+    u64::from_str_radix(digits, radix).is_ok_and(|n| n == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_zero_hostid;
+
+    #[test]
+    fn decimal_zero_is_zero() {
+        assert!(is_zero_hostid("0"));
+    }
+
+    #[test]
+    fn hex_zero_padded_is_zero() {
+        assert!(is_zero_hostid("00000000"));
+    }
+
+    #[test]
+    fn lowercase_hex_prefix_zero_is_zero() {
+        assert!(is_zero_hostid("0x0"));
+    }
+
+    #[test]
+    fn uppercase_hex_prefix_zero_is_zero() {
+        assert!(is_zero_hostid("0X00000000"));
+    }
+
+    #[test]
+    fn nonzero_hex_is_not_zero() {
+        assert!(!is_zero_hostid("4f988f8f"));
+    }
+
+    #[test]
+    fn non_numeric_value_is_not_zero() {
+        assert!(!is_zero_hostid("deadbeef-not-a-number"));
     }
 }


### PR DESCRIPTION
Fixes #9

## Summary
- reject zero-value illumos hostid sentinels after normalization
- add illumos-specific zero hostid unit tests mirroring the BSD coverage
- document the behavior and note it in the changelog

## Testing
- cargo test -p host-identity illumos
